### PR TITLE
Fix tests for best and worst event calcs,

### DIFF
--- a/ItHappened.Application/Services/EventTrackerService/EventTrackerService.cs
+++ b/ItHappened.Application/Services/EventTrackerService/EventTrackerService.cs
@@ -115,6 +115,13 @@ namespace ItHappened.Application.Services.EventTrackerService
                 return Status.WrongEventCreatorId;
             }
 
+            if (!tracker.IsTrackerAndEventCustomizationsMatch(@event))
+            {
+                Log.Information(
+                    $"Can't add event {@event.Id} to tracker id: {trackerId}. Tracker and event customizations don't match.");
+                return Status.WrongEventCustomisation;
+            }
+
             _eventRepository.AddEvent(@event);
             Log.Information(
                 $"Event: {@event.Id} added to tracker: {trackerId}");

--- a/ItHappened.Application/Services/EventTrackerService/EventTrackerServiceStatusCodes.cs
+++ b/ItHappened.Application/Services/EventTrackerService/EventTrackerServiceStatusCodes.cs
@@ -7,6 +7,7 @@
         TrackerDontExist,
         WrongEventCreatorId,
         EventDontExist,
-        EventAlreadyExist
+        EventAlreadyExist,
+        WrongEventCustomisation
     }
 }

--- a/ItHappened.Domain/EventTracker/EventTracker.cs
+++ b/ItHappened.Domain/EventTracker/EventTracker.cs
@@ -52,13 +52,13 @@ namespace ItHappened.Domain
             HasComment = eventTrackerBuilder.HasComment;
         }
         
-        private bool IsTrackerAndEventCustomizationsMatch(Event newEvent)
+        public bool IsTrackerAndEventCustomizationsMatch(Event newEvent)
         {
-            if (HasPhoto != newEvent.Photo.IsSome) return true;
-            if (HasScale != newEvent.Scale.IsSome) return true;
-            if (HasRating != newEvent.Rating.IsSome) return true;
-            if (HasGeoTag != newEvent.GeoTag.IsSome) return true;
-            return HasComment != newEvent.Comment.IsSome;
+            if (HasPhoto != newEvent.Photo.IsSome) return false;
+            if (HasScale != newEvent.Scale.IsSome) return false;
+            if (HasRating != newEvent.Rating.IsSome) return false;
+            if (HasGeoTag != newEvent.GeoTag.IsSome) return false;
+            return HasComment == newEvent.Comment.IsSome;
         }
     }
 }

--- a/ItHappened.UnitTests/EventTrackerTests.cs
+++ b/ItHappened.UnitTests/EventTrackerTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using ItHappened.Application.Services.EventTrackerService;
+using ItHappened.Domain;
+using ItHappened.Infrastructure.Repositories;
+using NUnit.Framework;
+
+namespace ItHappened.UnitTests
+{
+    public class EventTrackerTests
+    {
+        private EventTracker _eventTracker;
+
+        [SetUp]
+        public void Init()
+        {
+            _eventTracker = CreateEventTracker();
+
+        }
+
+        [Test]
+        public void IsTrackerAndEventCustomizationsMatchWhenCustomisationDiffers_ReturnFalse()
+        {
+            var eventToCompare = CreateEvent(Guid.NewGuid(), _eventTracker.Id);
+            eventToCompare.Comment = new Comment("comment");
+
+            var isMatch = _eventTracker.IsTrackerAndEventCustomizationsMatch(eventToCompare);
+            
+            Assert.False(isMatch);
+            Assert.AreNotEqual(_eventTracker.HasComment, eventToCompare.Comment.IsSome);
+            Assert.AreEqual(_eventTracker.HasPhoto, eventToCompare.Photo.IsSome);
+            Assert.AreEqual(_eventTracker.HasGeoTag, eventToCompare.GeoTag.IsSome);
+            Assert.AreEqual(_eventTracker.HasRating, eventToCompare.Rating.IsSome);
+            Assert.AreEqual(_eventTracker.HasScale, eventToCompare.Scale.IsSome);
+        }
+        
+        [Test]
+        public void IsTrackerAndEventCustomizationsMatchWhenCustomisationTheSame_ReturnTrue()
+        {
+            var trackerWithCommentAndGeoTag = CreateEventTrackerWithCommentAndGeoTag();
+            var eventToCompare = CreateEvent(Guid.NewGuid(), _eventTracker.Id);
+            eventToCompare.Comment = new Comment("comment");
+            eventToCompare.GeoTag = new GeoTag(54.1, 63.2);
+
+            var isMatch = trackerWithCommentAndGeoTag.IsTrackerAndEventCustomizationsMatch(eventToCompare);
+            
+            Assert.True(isMatch);
+            Assert.AreEqual(trackerWithCommentAndGeoTag.HasComment, eventToCompare.Comment.IsSome);
+            Assert.AreEqual(trackerWithCommentAndGeoTag.HasPhoto, eventToCompare.Photo.IsSome);
+            Assert.AreEqual(trackerWithCommentAndGeoTag.HasGeoTag, eventToCompare.GeoTag.IsSome);
+            Assert.AreEqual(trackerWithCommentAndGeoTag.HasRating, eventToCompare.Rating.IsSome);
+            Assert.AreEqual(trackerWithCommentAndGeoTag.HasScale, eventToCompare.Scale.IsSome);
+        }
+        
+        private EventTracker CreateEventTracker()
+        {
+            var tracker = EventTrackerBuilder
+                .Tracker(Guid.NewGuid(), Guid.NewGuid(), "tracker")
+                .Build();
+
+            return tracker;
+        }
+        
+        private EventTracker CreateEventTrackerWithCommentAndGeoTag()
+        {
+            var tracker = EventTrackerBuilder
+                .Tracker(Guid.NewGuid(), Guid.NewGuid(), "tracker")
+                .WithComment()
+                .WithGeoTag()
+                .Build();
+
+            return tracker;
+        }
+
+        private Event CreateEvent(Guid creatorId, Guid trackerId)
+        {
+            return EventBuilder
+                .Event(Guid.NewGuid(), creatorId, trackerId, DateTimeOffset.Now, "event: " + $"{creatorId}")
+                .Build();
+        }
+    }
+}

--- a/ItHappened.UnitTests/ServicesTests/EventTrackerServiceTests.cs
+++ b/ItHappened.UnitTests/ServicesTests/EventTrackerServiceTests.cs
@@ -181,6 +181,21 @@ namespace ItHappened.UnitTests.ServicesTests
         }
 
         [Test]
+        public void AddEventToTrackerWhenEventCustomisationDontMatchTrackerCustomisation_WrongEventCustomisationStatus()
+        {
+            var userId = Guid.NewGuid();
+            var tracker = CreateEventTracker(userId);
+            _eventTrackerRepository.SaveTracker(tracker);
+            var eventToAdd = CreateEvent(userId, tracker.Id);
+            eventToAdd.Comment = new Comment("comment");
+            const EventTrackerServiceStatusCodes expected = EventTrackerServiceStatusCodes.WrongEventCustomisation;
+            
+            var actual = _eventTrackerService.AddEventToTracker(userId, tracker.Id, eventToAdd);
+            
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
         public void RemoveEventFromNonExistentTracker_TrackerDontExistStatus()
         {
             const EventTrackerServiceStatusCodes expected = EventTrackerServiceStatusCodes.TrackerDontExist;

--- a/ItHappened.UnitTests/ServicesTests/EventTrackerServiceTests.cs
+++ b/ItHappened.UnitTests/ServicesTests/EventTrackerServiceTests.cs
@@ -193,6 +193,11 @@ namespace ItHappened.UnitTests.ServicesTests
             var actual = _eventTrackerService.AddEventToTracker(userId, tracker.Id, eventToAdd);
             
             Assert.AreEqual(expected, actual);
+            Assert.AreNotEqual(tracker.HasComment, eventToAdd.Comment.IsSome);
+            Assert.AreEqual(tracker.HasPhoto, eventToAdd.Photo.IsSome);
+            Assert.AreEqual(tracker.HasGeoTag, eventToAdd.GeoTag.IsSome);
+            Assert.AreEqual(tracker.HasRating, eventToAdd.Rating.IsSome);
+            Assert.AreEqual(tracker.HasScale, eventToAdd.Scale.IsSome);
         }
 
         [Test]

--- a/ItHappened.UnitTests/StatisticsCalculatorsTests/BestEventCalculatorTests.cs
+++ b/ItHappened.UnitTests/StatisticsCalculatorsTests/BestEventCalculatorTests.cs
@@ -34,7 +34,9 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             _events[0].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(91);
             _events[1].Rating = 1;
             _events[1].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(8);
-            var actual = _bestEventCalculator.Calculate(_eventTracker).ConvertTo<BestEventFact>();
+            
+            var actual = _bestEventCalculator.Calculate(_eventTracker);
+            
             Assert.IsTrue(actual.IsNone);
         }
 
@@ -44,7 +46,9 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             _eventRepository.AddEvent(CreateEventWithoutComment(_creatorId));
             _events[1].Rating = 1;
             _events[1].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(8);
-            var actual = _bestEventCalculator.Calculate(_eventTracker).ConvertTo<BestEventFact>();
+            
+            var actual = _bestEventCalculator.Calculate(_eventTracker);
+            
             Assert.IsTrue(actual.IsNone);
         }
 
@@ -55,7 +59,9 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             _events[0].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(91);
             _events[1].Rating = 1;
             _events[1].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(6);
-            var actual = _bestEventCalculator.Calculate(_eventTracker).ConvertTo<BestEventFact>();
+            
+            var actual = _bestEventCalculator.Calculate(_eventTracker);
+            
             Assert.IsTrue(actual.IsNone);
         }
 

--- a/ItHappened.UnitTests/StatisticsCalculatorsTests/BestEventCalculatorTests.cs
+++ b/ItHappened.UnitTests/StatisticsCalculatorsTests/BestEventCalculatorTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using ItHappened.Domain;
 using ItHappened.Domain.Statistics;
 using ItHappened.Infrastructure.Repositories;
+using LanguageExt.UnsafeValueAccess;
 using NUnit.Framework;
 
 namespace ItHappened.UnitTests.StatisticsCalculatorsTests
@@ -63,14 +64,20 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
         {
             _events[0].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(91);
             var event10 = CreateEventWithoutComment(_creatorId);
+            event10.Comment = new Comment("123");
             event10.Rating = 9;
             event10.HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(8);
-            _eventRepository.AddEvent(CreateEventWithoutComment(_creatorId));
-            
+            _eventRepository.AddEvent(event10);
+
             var optionalBestEventFact = _bestEventCalculator.Calculate(_eventTracker).ConvertTo<BestEventFact>();
+            var bestEventFact = optionalBestEventFact.ValueUnsafe();
             
             Assert.IsTrue(optionalBestEventFact.IsSome);
-            //TODO: проверить факт подбробнее
+            Assert.AreEqual(bestEventFact.Priority, event10.Rating.ValueUnsafe());
+            Assert.AreEqual(bestEventFact.EventReference, event10);
+            Assert.AreEqual(bestEventFact.HappensDate, event10.HappensDate);
+            Assert.AreEqual(bestEventFact.Comment.Text, event10.Comment.ValueUnsafe().Text);
+            Assert.AreEqual(bestEventFact.FactName, "Лучшее событие");
         }
 
         private Event CreateEventWithoutComment(Guid creatorId)

--- a/ItHappened.UnitTests/StatisticsCalculatorsTests/IFactToFactConvertorExtensions.cs
+++ b/ItHappened.UnitTests/StatisticsCalculatorsTests/IFactToFactConvertorExtensions.cs
@@ -3,7 +3,7 @@ using LanguageExt;
 
 namespace ItHappened.UnitTests.StatisticsCalculatorsTests
 {
-    public static class FromIFactToFactConvertorExtensions
+    public static class FromIFactToFactConverterExtensions
     {
         public static Option<T> ConvertTo<T>(this Option<IStatisticsFact> fact)
         {

--- a/ItHappened.UnitTests/StatisticsCalculatorsTests/WorstEventCalculatorTests.cs
+++ b/ItHappened.UnitTests/StatisticsCalculatorsTests/WorstEventCalculatorTests.cs
@@ -1,125 +1,134 @@
-﻿//TODO 
+﻿ using System;
+ using System.Collections.Generic;
+ using ItHappend.Domain.Statistics;
+ using ItHappened.Domain;
+ using ItHappened.Domain.Statistics;
+ using ItHappened.Infrastructure.Repositories;
+ using LanguageExt;
+ using LanguageExt.UnsafeValueAccess;
+ using NUnit.Framework;
 
-// using System;
-// using System.Collections.Generic;
-// using ItHappened.Domain;
-// using ItHappened.Domain.Statistics;
-// using ItHappened.Infrastructure.Repositories;
-// using LanguageExt;
-// using NUnit.Framework;
-//
-// namespace ItHappened.UnitTests.StatisticsCalculatorsTests
-// {
-//     public class WorstEventCalculatorTests
-//     {
-//         private const int InitialEventsNumber = 9;
-//         private Guid _creatorId;
-//         private List<Event> _events;
-//         private EventTracker _eventTracker;
-//         private WorstEventCalculator _worstEventCalculator;
-//         private IEventRepository _eventRepository;
-//         
-//         [SetUp]
-//         public void Init()
-//         {
-//             _eventRepository = new EventRepository();
-//             _creatorId = Guid.NewGuid();
-//             _events = CreateEvents(_creatorId, InitialEventsNumber);
-//             _eventTracker = CreateEventTracker();
-//             _worstEventCalculator = new WorstEventCalculator(_eventRepository);
-//         }
-//
-//         [Test]
-//         public void CalculateLessThanRequiredNumberEvents_ReturnNone()
-//         {
-//             //arrange
-//             _events[0].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(91);
-//             _events[1].Rating = 1;
-//             _events[1].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(8);
-//             var expected = Option<IStatisticsFact>.None;
-//
-//             //act
-//             var actual = _worstEventCalculator.Calculate(_eventTracker);
-//
-//             //assert
-//             Assert.AreEqual(expected, actual);
-//         }
-//
-//         [Test]
-//         public void CalculateWithoutOldEnoughEvent_ReturnNone()
-//         {
-//             //arrange
-//             _events.Add(CreateEventWithoutComment(_creatorId));
-//             _events[1].Rating = 1;
-//             _events[1].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(8);
-//             var expected = Option<IStatisticsFact>.None;
-//
-//             //act
-//             var actual = _worstEventCalculator.Calculate(_eventTracker);
-//
-//             //assert
-//             Assert.AreEqual(expected, actual);
-//         }
-//
-//         [Test]
-//         public void CalculateWhenWorstEventHappenedLessThanWeekAgo_ReturnNone()
-//         {
-//             //arrange
-//             _events.Add(CreateEventWithoutComment(_creatorId));
-//             _events[0].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(91);
-//             _events[1].Rating = 1;
-//             _events[1].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(6);
-//             var expected = Option<IStatisticsFact>.None;
-//
-//             //act
-//             var actual = _worstEventCalculator.Calculate(_eventTracker);
-//
-//             //assert
-//             Assert.AreEqual(expected, actual);
-//         }
-//
-//         [Test]
-//         public void CalculateGoodCase_ReturnsFact()
-//         {
-//             //arrange
-//             _events[0].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(91);
-//             _events.Add(CreateEventWithoutComment(_creatorId));
-//             _events[9].Rating = 1;
-//             _events[9].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(8);
-//
-//             //act
-//             var worstEvent = _worstEventCalculator.Calculate(_eventTracker);
-//
-//             //assert
-//             Assert.True(worstEvent.IsSome);
-//         }
-//
-//         private Event CreateEventWithoutComment(Guid creatorId)
-//         {
-//             return EventBuilder
-//                 .Event(Guid.NewGuid(), creatorId, _eventTracker.Id, DateTimeOffset.Now, "tittle")
-//                 .WithRating(5)
-//                 .Build();
-//         }
-//
-//         private List<Event> CreateEvents(Guid creatorId, int quantity)
-//         {
-//             var events = new List<Event>();
-//             for (var i = 0; i < quantity; i++)
-//                 events.Add(EventBuilder
-//                     .Event(Guid.NewGuid(), creatorId, _eventTracker.Id, DateTimeOffset.Now, "tittle")
-//                     .WithComment("comment")
-//                     .WithRating(5)
-//                     .Build());
-//             return events;
-//         }
-//
-//         private EventTracker CreateEventTracker()
-//         {
-//             var tracker = EventTrackerBuilder
-//                 .Tracker(Guid.NewGuid(), _eventTracker.Id, "tracker")
-//                 .Build();
-//             return tracker;
-//         }
-//     }
-// }
+ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
+ {
+     public class WorstEventCalculatorTests
+     {
+         private const int InitialEventsNumber = 9;
+         private Guid _creatorId;
+         private List<Event> _events;
+         private EventTracker _eventTracker;
+         private WorstEventCalculator _worstEventCalculator;
+         private IEventRepository _eventRepository;
+         
+         [SetUp]
+         public void Init()
+         {
+             _eventRepository = new EventRepository();
+             _creatorId = Guid.NewGuid();
+             _eventTracker = CreateEventTracker();
+             _events = CreateEvents(_creatorId, InitialEventsNumber);
+             _eventRepository.AddRangeOfEvents(_events);
+             _worstEventCalculator = new WorstEventCalculator(_eventRepository);
+         }
+
+         [Test]
+         public void CalculateLessThanRequiredNumberEvents_ReturnNone()
+         {
+             //arrange
+             _events[0].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(91);
+             _events[1].Rating = 1;
+             _events[1].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(8);
+             var expected = Option<IStatisticsFact>.None;
+
+             //act
+             var actual = _worstEventCalculator.Calculate(_eventTracker);
+
+             //assert
+             Assert.AreEqual(expected, actual);
+         }
+
+         [Test]
+         public void CalculateWithoutOldEnoughEvent_ReturnNone()
+         {
+             //arrange
+             _events.Add(CreateEventWithoutComment(_creatorId));
+             _events[1].Rating = 1;
+             _events[1].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(8);
+             var expected = Option<IStatisticsFact>.None;
+
+             //act
+             var actual = _worstEventCalculator.Calculate(_eventTracker);
+
+             //assert
+             Assert.AreEqual(expected, actual);
+         }
+
+         [Test]
+         public void CalculateWhenWorstEventHappenedLessThanWeekAgo_ReturnNone()
+         {
+             //arrange
+             _events.Add(CreateEventWithoutComment(_creatorId));
+             _events[0].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(91);
+             _events[1].Rating = 1;
+             _events[1].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(6);
+             var expected = Option<IStatisticsFact>.None;
+
+             //act
+             var actual = _worstEventCalculator.Calculate(_eventTracker);
+
+             //assert
+             Assert.AreEqual(expected, actual);
+         }
+
+         [Test]
+         public void CalculateGoodCase_ReturnsFact()
+         {
+             //arrange
+             _events[0].HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(91);
+             var event10 = CreateEventWithoutComment(_creatorId);
+             event10.Comment = new Comment("123");
+             event10.Rating = 1;
+             event10.HappensDate = DateTimeOffset.Now - TimeSpan.FromDays(8);
+             _eventRepository.AddEvent(event10);
+
+             //act
+             var optionalWorstEventFact = 
+                 _worstEventCalculator.Calculate(_eventTracker).ConvertTo<WorstEventFact>();
+             var worstEventFact = optionalWorstEventFact.ValueUnsafe();
+
+             //assert
+             Assert.True(optionalWorstEventFact.IsSome);
+             Assert.AreEqual(worstEventFact.Priority, 10 - event10.Rating.ValueUnsafe());
+             Assert.AreEqual(worstEventFact.HappensDate, event10.HappensDate);
+             Assert.AreEqual(worstEventFact.Comment.Text, event10.Comment.ValueUnsafe().Text);
+             Assert.AreEqual(worstEventFact.FactName, "Худшее событие");
+         }
+
+         private Event CreateEventWithoutComment(Guid creatorId)
+         {
+             return EventBuilder
+                 .Event(Guid.NewGuid(), creatorId, _eventTracker.Id, DateTimeOffset.Now, "tittle")
+                 .WithRating(5)
+                 .Build();
+         }
+
+         private List<Event> CreateEvents(Guid creatorId, int quantity)
+         {
+             var events = new List<Event>();
+             for (var i = 0; i < quantity; i++)
+                 events.Add(EventBuilder
+                     .Event(Guid.NewGuid(), creatorId, _eventTracker.Id, DateTimeOffset.Now, "tittle")
+                     .WithComment("comment")
+                     .WithRating(5)
+                     .Build());
+             return events;
+         }
+
+         private EventTracker CreateEventTracker()
+         {
+             var tracker = EventTrackerBuilder
+                 .Tracker(Guid.NewGuid(), Guid.NewGuid(), "tracker")
+                 .Build();
+             return tracker;
+         }
+     }
+ }


### PR DESCRIPTION
1. Fix tests for best and worst event calcs
2. Make IsTrackerAndEventCustomizationsMatch method public in EventTracker.cs , fix its conditions.
3. Add customisation check in EventTrackerService.cs when add new event to tracker, add test for this case, add status code for this case
4. Add EventTrackerTests.cs with tests for method IsTrackerAndEventCustomizationsMatch 