### PR TITLE
refactoring all builders

### DIFF
--- a/ItHappened.API/Controllers/FactStatisticsController.cs
+++ b/ItHappened.API/Controllers/FactStatisticsController.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using ItHappened.Application.Services.EventTrackerService;
+using ItHappened.Application.Services.StatisticService;
+using ItHappened.Domain;
+using ItHappened.Domain.Statistics;
+using ItHappened.Infrastructure.Repositories;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ItHappened.API.Controllers
+{
+    [Route("user")]
+    public class FactStatisticsController : ControllerBase
+    {
+
+        [HttpGet]
+        [Route("{userId}/CalculateAll")]
+        public IActionResult CalculateAll([FromRoute] Guid userId)
+        {
+            var statisticsService = new StatisticsService(new EventTrackerRepository(), new GeneralFactProvider(), new SpecificFactProvider());
+
+            var eventTrackerService = new EventTrackerService(new EventTrackerRepository(), new EventRepository());
+            var trackerId = eventTrackerService.CreateTracker(EventTracker.Create(Guid.NewGuid(), userId, "first tarcker").WithComment().Build());
+
+            for (var i = 0; i < 10; i++)
+                eventTrackerService.AddEventToTracker(userId, trackerId, Event.Create(Guid.NewGuid(), trackerId, userId, DateTimeOffset.Now, $"EmptyName{i}").Build());
+
+            var facts = statisticsService.GetGeneralTrackersFacts(userId);
+            return Ok(JsonSerializer.Serialize(facts));
+
+        }
+
+        [HttpGet]
+        [Route("{userId}/Calculate/{factStatisticsId}")]
+        public IActionResult Calculate([FromRoute] Guid userId, [FromRoute] Guid factStatisticsId)
+        {
+            // var statisticsService = new StatisticsService(new EventTrackerRepository());
+            //no implementation with one fact :(
+            //var fact = statisticsService.GetFacts(userId, factStatisticsId);
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ItHappened.Application/Services/EventTrackerService/EventTrackerService.cs
+++ b/ItHappened.Application/Services/EventTrackerService/EventTrackerService.cs
@@ -38,44 +38,8 @@ namespace ItHappened.Application.Services.EventTrackerService
             return Status.Ok;;
         }
 
-        public Guid CreateTracker(
-            Guid creatorId,
-            string trackerName,
-            bool hasPhoto,
-            bool hasScale,
-            string scaleMeasurementUnit,
-            bool hasRating,
-            bool hashGeoTag,
-            bool hasComment)
+        public Guid CreateTracker(EventTracker tracker)
         {
-            var trackerBuilder = EventTrackerBuilder
-                .Tracker(creatorId, Guid.NewGuid(), trackerName);
-            if (hasPhoto)
-            {
-                trackerBuilder = trackerBuilder.WithPhoto();
-            }
-
-            if (hasScale)
-            {
-                trackerBuilder = trackerBuilder.WithScale(scaleMeasurementUnit);
-            }
-
-            if (hasRating)
-            {
-                trackerBuilder = trackerBuilder.WithRating();
-            }
-
-            if (hashGeoTag)
-            {
-                trackerBuilder = trackerBuilder.WithGeoTag();
-            }
-
-            if (hasComment)
-            {
-                trackerBuilder = trackerBuilder.WithComment();
-            }
-
-            var tracker = trackerBuilder.Build();
             _eventTrackerRepository.SaveTracker(tracker);
             return tracker.Id;
         }

--- a/ItHappened.Application/Services/EventTrackerService/IEventTrackerService.cs
+++ b/ItHappened.Application/Services/EventTrackerService/IEventTrackerService.cs
@@ -7,18 +7,8 @@ namespace ItHappened.Application.Services.EventTrackerService
 {
     public interface IEventTrackerService
     {
-        Guid CreateTracker(
-            Guid creatorId,
-            string trackerName,
-            bool hasPhoto,
-            bool hasScale,
-            string scaleMeasurementUnit,
-            bool hasRating,
-            bool hashGeoTag,
-            bool hasComment);
-        
+        Guid CreateTracker(EventTracker eventTracker);       
         EventTrackerServiceStatusCodes DeleteTracker(Guid trackerId, Guid creatorId);
-
         IReadOnlyCollection<EventTracker> GetAllUserTrackers(Guid userId);
         EventTrackerServiceStatusCodes AddEventToTracker(Guid initiatorId, Guid trackerId, Event @event);
         EventTrackerServiceStatusCodes RemoveEventFromTracker(Guid initiatorId, Guid trackerId, Guid eventId);

--- a/ItHappened.Domain/Event/Event.cs
+++ b/ItHappened.Domain/Event/Event.cs
@@ -8,26 +8,66 @@ namespace ItHappened.Domain
         public Guid Id { get; }
         public Guid CreatorId { get; }
         public Guid TrackerId { get; }
-        public DateTimeOffset HappensDate { get; set; }
-        public string Title { get; set; }
-        public Option<Photo> Photo { get; set; }
-        public Option<double> Scale { get; set; }
-        public Option<double> Rating { get; set; }
-        public Option<GeoTag> GeoTag { get; set; }
-        public Option<Comment> Comment { get; set; }
+        public DateTimeOffset HappensDate { get; private set; }
+        public string Title { get; private set; }
+        public Option<Photo> Photo { get; private set; }
+        public Option<double> Scale { get; private set; }
+        public Option<double> Rating { get; private set; }
+        public Option<GeoTag> GeoTag { get; private set; }
+        public Option<Comment> Comment { get; private set; }
 
-        public Event(EventBuilder eventBuilder)
+        private Event(Guid id, Guid trackerId, Guid creatorId, DateTimeOffset happensDate, string title)
         {
-            CreatorId = eventBuilder.CreatorId;
-            Id = eventBuilder.Id;
-            TrackerId = eventBuilder.TrackerId;
-            Title = eventBuilder.Title;
-            HappensDate = eventBuilder.HappensDate;
-            Photo = eventBuilder.Photo;
-            Scale = eventBuilder.Scale;
-            Rating = eventBuilder.Rating;
-            GeoTag = eventBuilder.GeoTag;
-            Comment = eventBuilder.Comment;
+            Id = id;
+            TrackerId = trackerId;
+            CreatorId = creatorId;
+            HappensDate = happensDate;
+            Title = title;
+        }
+
+        public static EventBuilder Create(Guid id, Guid trackerId, Guid creatorId, DateTimeOffset happensDate, string title)
+            => new EventBuilder(new Event(id, trackerId, creatorId, happensDate, title));
+
+        public class EventBuilder
+        {
+            private readonly Event _event;
+
+            internal EventBuilder(Event @event)
+            {
+                _event = @event;
+            }
+
+            public EventBuilder WithPhoto(Photo photo)
+            {
+                _event.Photo = Option<Photo>.Some(photo);
+                return this;
+            }
+
+            public EventBuilder WithScale(double scale)
+            {
+                _event.Scale = Option<double>.Some(scale);
+                return this;
+            }
+
+            public EventBuilder WithRating(double rating)
+            {
+                _event.Rating = Option<double>.Some(rating);
+                return this;
+            }
+
+            public EventBuilder WithGeoTag(GeoTag geoTag)
+            {
+                _event.GeoTag = Option<GeoTag>.Some(geoTag);
+                return this;
+            }
+
+            public EventBuilder WithComment(string text)
+            {
+                _event.Comment = Option<Comment>.Some(new Comment(text));
+                return this;
+            }
+
+            public Event Build() => _event;
         }
     }
 }

--- a/ItHappened.Domain/Event/EventBuilder.cs
+++ b/ItHappened.Domain/Event/EventBuilder.cs
@@ -1,66 +1,66 @@
-﻿using System;
-using LanguageExt;
+﻿//using System;
+//using LanguageExt;
 
-namespace ItHappened.Domain
-{
-    public class EventBuilder
-    {
-        internal Option<Comment> Comment = Option<Comment>.None;
-        internal Option<GeoTag> GeoTag = Option<GeoTag>.None;
-        internal Option<Photo> Photo = Option<Photo>.None;
-        internal Option<double> Rating = Option<double>.None;
-        internal Option<double> Scale = Option<double>.None;
-        internal Guid Id { get; private set; }
-        internal Guid CreatorId { get; private set; }
-        internal Guid TrackerId { get; private set; }
-        internal DateTimeOffset HappensDate { get; private set; }
-        internal string Title { get; private set; }
+//namespace ItHappened.Domain
+//{
+//    public class EventBuilder
+//    {
+//        internal Option<Comment> Comment = Option<Comment>.None;
+//        internal Option<GeoTag> GeoTag = Option<GeoTag>.None;
+//        internal Option<Photo> Photo = Option<Photo>.None;
+//        internal Option<double> Rating = Option<double>.None;
+//        internal Option<double> Scale = Option<double>.None;
+//        internal Guid Id { get; private set; }
+//        internal Guid CreatorId { get; private set; }
+//        internal Guid TrackerId { get; private set; }
+//        internal DateTimeOffset HappensDate { get; private set; }
+//        internal string Title { get; private set; }
 
-        public Event Build()
-        {
-            return new Event(this);
-        }
+//        public Event Build()
+//        {
+//            return new Event(this);
+//        }
 
-        public static EventBuilder Event(Guid id, Guid creatorId, Guid trackerId, DateTimeOffset happensDate, string title)
-        {
-            return new EventBuilder
-            {
-                Id = id,
-                CreatorId = creatorId,
-                TrackerId = trackerId,
-                HappensDate = happensDate,
-                Title = title
-            };
-        }
+//        public static EventBuilder Event(Guid id, Guid creatorId, Guid trackerId, DateTimeOffset happensDate, string title)
+//        {
+//            return new EventBuilder
+//            {
+//                Id = id,
+//                CreatorId = creatorId,
+//                TrackerId = trackerId,
+//                HappensDate = happensDate,
+//                Title = title
+//            };
+//        }
 
-        public EventBuilder WithPhoto(Photo photo)
-        {
-            Photo = Option<Photo>.Some(photo);
-            return this;
-        }
+//        public EventBuilder WithPhoto(Photo photo)
+//        {
+//            Photo = Option<Photo>.Some(photo);
+//            return this;
+//        }
 
-        public EventBuilder WithScale(double scale)
-        {
-            Scale = Option<double>.Some(scale);
-            return this;
-        }
+//        public EventBuilder WithScale(double scale)
+//        {
+//            Scale = Option<double>.Some(scale);
+//            return this;
+//        }
 
-        public EventBuilder WithRating(double rating)
-        {
-            Rating = Option<double>.Some(rating);
-            return this;
-        }
+//        public EventBuilder WithRating(double rating)
+//        {
+//            Rating = Option<double>.Some(rating);
+//            return this;
+//        }
 
-        public EventBuilder WithGeoTag(GeoTag geoTag)
-        {
-            GeoTag = Option<GeoTag>.Some(geoTag);
-            return this;
-        }
+//        public EventBuilder WithGeoTag(GeoTag geoTag)
+//        {
+//            GeoTag = Option<GeoTag>.Some(geoTag);
+//            return this;
+//        }
 
-        public EventBuilder WithComment(string text)
-        {
-            Comment = Option<Comment>.Some(new Comment(text));
-            return this;
-        }
-    }
-}
+//        public EventBuilder WithComment(string text)
+//        {
+//            Comment = Option<Comment>.Some(new Comment(text));
+//            return this;
+//        }
+//    }
+//}

--- a/ItHappened.Domain/Event/IEventBuilder.cs
+++ b/ItHappened.Domain/Event/IEventBuilder.cs
@@ -9,10 +9,10 @@ namespace ItHappened.Domain
         DateTimeOffset HappensDate { get; }
         string Title { get; }
         Event Build();
-        EventBuilder WithPhoto(Photo photo);
-        EventBuilder WithScale(double scale);
-        EventBuilder WithRating(double rating);
-        EventBuilder WithGeoTag(GeoTag geoTag);
-        EventBuilder WithComment(string comment);
+        Event.EventBuilder WithPhoto(Photo photo);
+        Event.EventBuilder WithScale(double scale);
+        Event.EventBuilder WithRating(double rating);
+        Event.EventBuilder WithGeoTag(GeoTag geoTag);
+        Event.EventBuilder WithComment(string comment);
     }
 }

--- a/ItHappened.Domain/EventTracker/EventTracker.cs
+++ b/ItHappened.Domain/EventTracker/EventTracker.cs
@@ -12,53 +12,77 @@ namespace ItHappened.Domain
         public string Name { get; }
         public Guid CreatorId { get; }
 
-        public bool HasPhoto { get; }
-        public bool HasScale { get; }
-        public bool HasRating { get; }
-        public bool HasGeoTag { get; }
-        public bool HasComment { get; }
+        public bool HasPhoto { get; private set; }
+        public bool HasScale { get; private set; }
+        public bool HasRating { get;  private set; }
+        public bool HasGeoTag { get; private set; }
+        public bool HasComment { get; private set; }
+        public Guid EventTrackerId { get; private set; }
 
         public Option<string> ScaleMeasurementUnit;
 
-        public EventTracker(Guid creatorId,
-            Guid id,
-            string name,
-            bool hasPhoto,
-            bool hasScale,
-            bool hasRating,
-            bool hasGeoTag,
-            bool hasComment)
+        private EventTracker(Guid eventTrackerId, Guid creatorId, string name)
         {
-            Id = id;
-            Name = name;
+            EventTrackerId = eventTrackerId;
             CreatorId = creatorId;
-            HasPhoto = hasPhoto;
-            HasScale = hasScale;
-            HasRating = hasRating;
-            HasGeoTag = hasGeoTag;
-            HasComment = hasComment;
+            Name = name;
         }
 
-        public EventTracker(EventTrackerBuilder eventTrackerBuilder)
+        public static EventTrackerBuilder Create(Guid eventTrackerId, Guid creatorId, string Name)
         {
-            Id = eventTrackerBuilder.Id;
-            Name = eventTrackerBuilder.Name;
-            CreatorId = eventTrackerBuilder.CreatorId;
-            HasPhoto = eventTrackerBuilder.HasPhoto;
-            HasScale = eventTrackerBuilder.HasScale;
-            ScaleMeasurementUnit = eventTrackerBuilder.ScaleMeasurementUnit;
-            HasRating = eventTrackerBuilder.HasRating;
-            HasGeoTag = eventTrackerBuilder.HashGeoTag;
-            HasComment = eventTrackerBuilder.HasComment;
+            return new EventTrackerBuilder(new EventTracker(eventTrackerId, creatorId, Name));
         }
-        
+
+        public class EventTrackerBuilder : IEventTrackerBuilder
+        {
+            private readonly EventTracker _eventTracker;
+
+            internal EventTrackerBuilder(EventTracker eventTracker)
+            {
+                _eventTracker = eventTracker;
+            }
+            public EventTrackerBuilder WithPhoto()
+            {
+                _eventTracker.HasPhoto = true;
+                return this;
+            }
+
+            public EventTrackerBuilder WithScale(string measurementUnit)
+            {
+                _eventTracker.HasScale = true;
+                _eventTracker.ScaleMeasurementUnit = Option<string>.Some(measurementUnit);
+                return this;
+            }
+
+            public EventTrackerBuilder WithRating()
+            {
+                _eventTracker.HasRating = true;
+                return this;
+            }
+
+            public EventTrackerBuilder WithGeoTag()
+            {
+                _eventTracker.HasGeoTag = true;
+                return this;
+            }
+
+            public EventTrackerBuilder WithComment()
+            {
+                _eventTracker.HasComment = true;
+                return this;
+            }
+
+            public EventTracker Build()
+            {
+                return _eventTracker;
+            }
+        }
+
         public bool IsTrackerAndEventCustomizationsMatch(Event newEvent)
-        {
-            if (HasPhoto != newEvent.Photo.IsSome) return false;
-            if (HasScale != newEvent.Scale.IsSome) return false;
-            if (HasRating != newEvent.Rating.IsSome) return false;
-            if (HasGeoTag != newEvent.GeoTag.IsSome) return false;
-            return HasComment == newEvent.Comment.IsSome;
-        }
+            => HasPhoto == newEvent.Photo.IsSome
+            && HasScale == newEvent.Scale.IsSome
+            && HasRating == newEvent.Rating.IsSome
+            && HasGeoTag == newEvent.GeoTag.IsSome
+            && HasComment == newEvent.Comment.IsSome;
     }
 }

--- a/ItHappened.Domain/EventTracker/EventTrackerBuilder.cs
+++ b/ItHappened.Domain/EventTracker/EventTrackerBuilder.cs
@@ -1,65 +1,58 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Mail;
 using LanguageExt;
 
 namespace ItHappened.Domain
 {
-    public class EventTrackerBuilder : IEventTrackerBuilder
-    {
-        public Guid Id { get; private set; }
-        public Guid CreatorId { get; private set; }
-        public string Name { get; private set; }
-        public Option<string> ScaleMeasurementUnit { get; private set; }
-        public bool HasPhoto { get; private set; }
-        public bool HasScale { get; private set; }
-        public bool HasRating { get; private set; }
-        public bool HashGeoTag { get; private set; }
-        public bool HasComment { get; private set; }
+    //public class EventTrackerBuilder : IEventTrackerBuilder
+    //{
+    //    private readonly EventTracker eventTracker;
 
-        public static EventTrackerBuilder Tracker(Guid creatorId, Guid trackerId, string name)
-        {
-            return new EventTrackerBuilder
-            {
-                CreatorId = creatorId,
-                Id = trackerId,
-                Name = name,
-            };
-        }
+    //    public static EventTrackerBuilder Tracker(Guid creatorId, Guid trackerId, string name)
+    //    {
+    //        return new EventTrackerBuilder
+    //        {
+    //            CreatorId = creatorId,
+    //            Id = trackerId,
+    //            Name = name,
+    //        };
+    //    }
         
-        public EventTrackerBuilder WithPhoto()
-        {
-            HasPhoto = true;
-            return this;
-        }
+    //    public EventTrackerBuilder WithPhoto()
+    //    {
+    //        eventTracker.HasPhoto = true;
+    //        return this;
+    //    }
 
-        public EventTrackerBuilder WithScale(string measurementUnit)
-        {
-            HasScale = true;
-            ScaleMeasurementUnit = Option<string>.Some(measurementUnit);
-            return this;
-        }
+    //    public EventTrackerBuilder WithScale(string measurementUnit)
+    //    {
+    //        HasScale = true;
+    //        ScaleMeasurementUnit = Option<string>.Some(measurementUnit);
+    //        return this;
+    //    }
 
-        public EventTrackerBuilder WithRating()
-        {
-            HasRating = true;
-            return this;
-        }
+    //    public EventTrackerBuilder WithRating()
+    //    {
+    //        HasRating = true;
+    //        return this;
+    //    }
 
-        public EventTrackerBuilder WithGeoTag()
-        {
-            HashGeoTag = true;
-            return this;
-        }
+    //    public EventTrackerBuilder WithGeoTag()
+    //    {
+    //        HashGeoTag = true;
+    //        return this;
+    //    }
 
-        public EventTrackerBuilder WithComment()
-        {
-            HasComment = true;
-            return this;
-        }
+    //    public EventTrackerBuilder WithComment()
+    //    {
+    //        HasComment = true;
+    //        return this;
+    //    }
 
-        public EventTracker Build()
-        {
-            return new EventTracker(this);
-        }
-    }
+    //    public EventTracker Build()
+    //    {
+    //        return new EventTracker(this);
+    //    }
+    //}
 }

--- a/ItHappened.Domain/EventTracker/IEventTrackerBuilder.cs
+++ b/ItHappened.Domain/EventTracker/IEventTrackerBuilder.cs
@@ -2,10 +2,10 @@
 {
     public interface IEventTrackerBuilder
     {
-        EventTrackerBuilder WithPhoto();
-        EventTrackerBuilder WithScale(string measurementUnit);
-        EventTrackerBuilder WithRating();
-        EventTrackerBuilder WithGeoTag();
-        EventTrackerBuilder WithComment();
+        EventTracker.EventTrackerBuilder WithPhoto();
+        EventTracker.EventTrackerBuilder WithScale(string measurementUnit);
+        EventTracker.EventTrackerBuilder WithRating();
+        EventTracker.EventTrackerBuilder WithGeoTag();
+        EventTracker.EventTrackerBuilder WithComment();
     }
 }


### PR DESCRIPTION
Парни, начал переносить АПИ по статистике и тут увидел, как реализованы билдеры... все делается не так) смотрите в код, я все исправил.

Во-первых, непонятно зачем мне билдер трэкера, если сервис трекера заставляет меня принимать кучу параметров, в которых я запутался. Во-вторых, если появятся еще поля в трэкере, то придется также изменять сервис трэкера, а это уже не по СОЛИДному) 

Перейдем к билдеру, который для событий. Зачем создавать билдер, который будет нести в себе все поля события? а потом передавать эти поля в событие? Это очень трудный способ - раз, а два - у вас сеттеры то публичные(потому что иначе не заполнить поля в событии), а они должны быть приватными. 

Можем обсудить завтра на дс.