### PR TITLE
Add title field to Event

### DIFF
--- a/ItHappened.API/Controllers/EventsController.cs
+++ b/ItHappened.API/Controllers/EventsController.cs
@@ -34,7 +34,7 @@ namespace ItHappened.Api.Controllers
         {
             var userId = User.GetUserId();
             var customParameters = _mapper.Map<EventCustomParameters>(request);
-            var eventId = _eventService.CreateEvent(userId, trackerId, request.HappensDate, customParameters);
+            var eventId = _eventService.CreateEvent(userId, trackerId, request.HappensDate, request.Title, customParameters);
             return Ok(_mapper.Map<EventPostResponse>(eventId));
         }
 

--- a/ItHappened.API/Models/Requests/EventRequest.cs
+++ b/ItHappened.API/Models/Requests/EventRequest.cs
@@ -5,6 +5,7 @@ namespace ItHappened.Api.Models.Requests
     public class EventRequest
     {
         public DateTimeOffset HappensDate { get; set; }
+        public string Title { get; set; }
         public string Photo { get; set; }
         public double? Scale { get; set; }
         public double? Rating { get; set; }

--- a/ItHappened.Application/Services/EventService/IEventService.cs
+++ b/ItHappened.Application/Services/EventService/IEventService.cs
@@ -6,7 +6,7 @@ namespace ItHappened.Application.Services.EventService
 {
     public interface IEventService
     {
-        Guid CreateEvent(Guid actorId, Guid trackerId, DateTimeOffset eventHappensDate,
+        Guid CreateEvent(Guid actorId, Guid trackerId, DateTimeOffset eventHappensDate, string title,
             EventCustomParameters customParameters);
 
         Event GetEvent(Guid actorId, Guid eventId);

--- a/ItHappened.Domain/Event/Event.cs
+++ b/ItHappened.Domain/Event/Event.cs
@@ -8,18 +8,21 @@ namespace ItHappened.Domain
         public Guid CreatorId { get; }
         public Guid TrackerId { get; }
         public DateTimeOffset HappensDate { get; }
+        public string Title { get; }
         public EventCustomParameters CustomizationsParameters { get; }
 
         public Event(Guid id,
             Guid creatorId,
             Guid trackerId,
             DateTimeOffset happensDate,
+            string title,
             EventCustomParameters customizationsParameters)
         {
             Id = id;
             CreatorId = creatorId;
             TrackerId = trackerId;
             HappensDate = happensDate;
+            Title = title;
             CustomizationsParameters = customizationsParameters;
         }
     }

--- a/ItHappened.Infrastructure/Mappers/DBToDomainMappingProfiles.cs
+++ b/ItHappened.Infrastructure/Mappers/DBToDomainMappingProfiles.cs
@@ -53,7 +53,12 @@ namespace ItHappened.Infrastructure.Mappers
             var photo = source.Photo.IsNull() ? Option<Photo>.None : Option<Photo>.Some(new Photo(source.Photo));
             var eventCustomParameters = new EventCustomParameters(photo, scale, rating, geoTag, comment);
             
-            return new Event(source.Id, source.CreatorId, source.TrackerId, source.HappensDate,
+            return new Event(
+                source.Id, 
+                source.CreatorId, 
+                source.TrackerId, 
+                source.HappensDate, 
+                source.Title,
                 eventCustomParameters);
         }
     }

--- a/ItHappened.Infrastructure/Mappers/EventDto.cs
+++ b/ItHappened.Infrastructure/Mappers/EventDto.cs
@@ -10,15 +10,13 @@ namespace ItHappened.Infrastructure.Mappers
         public Guid CreatorId { get; set; }
         public Guid TrackerId { get; set; }
         public DateTimeOffset HappensDate { get; set; }
-      
-        [Column(TypeName = "image")]
-        public byte[] Photo { get; set; }
+        public string Title { get; set; }
+
+        [Column(TypeName = "image")] public byte[] Photo { get; set; }
         public double? Scale { get; set; }
         public double? Rating { get; set; }
         public double? LatitudeGeo { get; set; }
         public double? LongitudeGeo { get; set; }
         public string Comment { get; set; }
-        
-        //public EventTrackerDto EventTrackerDto { get; set; }
     }
 }

--- a/ItHappened.UnitTests/EventTests.cs
+++ b/ItHappened.UnitTests/EventTests.cs
@@ -29,7 +29,7 @@ namespace ItHappened.UnitTests
             _photo = new Photo(new byte[] {0x1, 0x2, 0x3});
             _rating = 299.0;
             _geoTag = new GeoTag(55.790514, 37.584822);
-            _title = "Tracker name";
+            _title = "Event title";
             _tracker = new EventTracker(Guid.NewGuid(), Guid.NewGuid(), _title,
                 new TrackerCustomizationSettings());
         }
@@ -40,7 +40,7 @@ namespace ItHappened.UnitTests
             //arrange
 
             //act
-            var @event = new Event(_eventId, _creatorId, _tracker.Id, _date, "Event title",
+            var @event = new Event(_eventId, _creatorId, _tracker.Id, _date, _title,
                 new EventCustomParameters());
 
             //assert

--- a/ItHappened.UnitTests/EventTests.cs
+++ b/ItHappened.UnitTests/EventTests.cs
@@ -16,7 +16,7 @@ namespace ItHappened.UnitTests
         private double _scale;
         private Comment _textComment;
         private EventTracker _tracker;
-
+        private string _title;
 
         [SetUp]
         public void Init()
@@ -29,7 +29,8 @@ namespace ItHappened.UnitTests
             _photo = new Photo(new byte[] {0x1, 0x2, 0x3});
             _rating = 299.0;
             _geoTag = new GeoTag(55.790514, 37.584822);
-            _tracker = new EventTracker(Guid.NewGuid(), Guid.NewGuid(), "Tracker name",
+            _title = "Tracker name";
+            _tracker = new EventTracker(Guid.NewGuid(), Guid.NewGuid(), _title,
                 new TrackerCustomizationSettings());
         }
 
@@ -39,12 +40,14 @@ namespace ItHappened.UnitTests
             //arrange
 
             //act
-            var @event = new Event(_eventId, _creatorId, _tracker.Id, _date, new EventCustomParameters());
+            var @event = new Event(_eventId, _creatorId, _tracker.Id, _date, "Event title",
+                new EventCustomParameters());
 
             //assert
             Assert.AreEqual(_eventId, @event.Id);
             Assert.AreEqual(_creatorId, @event.CreatorId);
             Assert.AreEqual(_date, @event.HappensDate);
+            Assert.AreEqual(_title, @event.Title);
 
             Assert.IsTrue(@event.CustomizationsParameters.Comment.IsNone);
             Assert.IsTrue(@event.CustomizationsParameters.Scale.IsNone);
@@ -62,7 +65,7 @@ namespace ItHappened.UnitTests
             var @event = new Event(_eventId,
                 _creatorId,
                 _tracker.Id,
-                _date,
+                _date, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.Some(_photo),
                     Option<double>.Some(_scale),
@@ -98,7 +101,7 @@ namespace ItHappened.UnitTests
             var @event = new Event(_eventId,
                 _creatorId,
                 _tracker.Id,
-                _date,
+                _date, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.Some(_scale),

--- a/ItHappened.UnitTests/EventTrackerTests.cs
+++ b/ItHappened.UnitTests/EventTrackerTests.cs
@@ -35,11 +35,11 @@ namespace ItHappened.UnitTests
             Assert.AreEqual(userId, tracker.CreatorId);
             Assert.AreEqual(tracker.Name, trackerName);
             Assert.AreEqual(scaleUnit, tracker.CustomizationSettings.ScaleMeasurementUnit.ValueUnsafe());
-            Assert.AreEqual(true, tracker.CustomizationSettings.IsPhotoRequired);
-            Assert.AreEqual(true, tracker.CustomizationSettings.IsRatingRequired);
-            Assert.AreEqual(true, tracker.CustomizationSettings.IsGeotagRequired);
-            Assert.AreEqual(true, tracker.CustomizationSettings.IsCommentRequired);
-            Assert.AreEqual(true, tracker.CustomizationSettings.IsScaleRequired);
+            Assert.True( tracker.CustomizationSettings.IsPhotoRequired);
+            Assert.True( tracker.CustomizationSettings.IsRatingRequired);
+            Assert.True( tracker.CustomizationSettings.IsGeotagRequired);
+            Assert.True( tracker.CustomizationSettings.IsCommentRequired);
+            Assert.True( tracker.CustomizationSettings.IsScaleRequired);
         }
 
         [Test]
@@ -214,7 +214,7 @@ namespace ItHappened.UnitTests
             var @event = new Event(eventId,
                 creatorId,
                 trackerId,
-                date,
+                date, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.Some(photo),
                     Option<double>.Some(scale),
@@ -236,7 +236,7 @@ namespace ItHappened.UnitTests
             var @event = new Event(eventId,
                 creatorId,
                 trackerId,
-                date,
+                date, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.Some(photo),
                     Option<double>.Some(scale),

--- a/ItHappened.UnitTests/ServicesTests/EventServiceTests.cs
+++ b/ItHappened.UnitTests/ServicesTests/EventServiceTests.cs
@@ -17,7 +17,7 @@ namespace ItHappened.UnitTests.ServicesTests
         private ITrackerRepository _trackerRepository;
         private IEventRepository _eventRepository;
         private IEventService _eventService;
-        
+
         [SetUp]
         public void Init()
         {
@@ -32,51 +32,51 @@ namespace ItHappened.UnitTests.ServicesTests
         public void CreateEventWhenNoRequiredTrackerInRepository_ThrowsException()
         {
             Assert.Throws<TrackerNotFoundException>(() =>
-                _eventService.CreateEvent(Guid.NewGuid(), _tracker.Id, DateTimeOffset.Now,
+                _eventService.CreateEvent(Guid.NewGuid(), _tracker.Id, DateTimeOffset.Now, "Event title",
                     new EventCustomParameters()));
         }
-        
-        
+
+
         [Test]
         public void CreateEventWhenUserCreateEventForNotHisOwnTracker_ThrowsException()
         {
             _trackerRepository.SaveTracker(_tracker);
-            
+
             Assert.Throws<NoPermissionsForTrackerException>(() =>
-                _eventService.CreateEvent(Guid.NewGuid(), _tracker.Id, DateTimeOffset.Now,
+                _eventService.CreateEvent(Guid.NewGuid(), _tracker.Id, DateTimeOffset.Now, "Event title",
                     new EventCustomParameters()));
         }
-        
+
         [Test]
         public void CreateEventWhenEventAndTrackerCustomizationDiffersAndCustomizationIsRequired_ThrowsException()
         {
             var tracker = TestingMethods.CreateTrackerWithRequiredCustomization(Guid.NewGuid(), "tracker",
                 new TrackerCustomizationSettings(
-                    true, 
                     true,
-                    Option<string>.Some("meter"), 
-                    true, 
-                    false, 
-                    true, 
+                    true,
+                    Option<string>.Some("meter"),
+                    true,
+                    false,
+                    true,
                     true));
             _trackerRepository.SaveTracker(tracker);
-            
+
             Assert.Throws<InvalidEventForTrackerException>(() =>
-                _eventService.CreateEvent(tracker.CreatorId, tracker.Id, DateTimeOffset.Now,
+                _eventService.CreateEvent(tracker.CreatorId, tracker.Id, DateTimeOffset.Now, "Event title",
                     new EventCustomParameters()));
         }
-        
+
         [Test]
         public void CreateEventWhenEventAndTrackerCustomizationEqualsAndCustomizationIsRequired_CreatesEvent()
         {
             var tracker = TestingMethods.CreateTrackerWithRequiredCustomization(Guid.NewGuid(), "tracker",
                 new TrackerCustomizationSettings(
-                    true, 
                     true,
-                    Option<string>.Some("meter"), 
-                    false, 
-                    true, 
-                    false, 
+                    true,
+                    Option<string>.Some("meter"),
+                    false,
+                    true,
+                    false,
                     true));
             _trackerRepository.SaveTracker(tracker);
             var newEventCustomization = new EventCustomParameters(
@@ -85,65 +85,66 @@ namespace ItHappened.UnitTests.ServicesTests
                 Option<double>.None,
                 Option<GeoTag>.Some(new GeoTag(10, 20)),
                 Option<Comment>.None);
-            
+
             var createdEventId = _eventService.CreateEvent(
-                tracker.CreatorId, 
-                tracker.Id, 
-                DateTimeOffset.Now,
+                tracker.CreatorId,
+                tracker.Id,
+                DateTimeOffset.Now, "Event title",
                 newEventCustomization);
-            
+
             Assert.True(_eventRepository.IsContainEvent(createdEventId));
-            Assert.AreEqual(newEventCustomization.GetHashCode(), 
+            Assert.AreEqual(newEventCustomization.GetHashCode(),
                 _eventRepository.LoadEvent(createdEventId).CustomizationsParameters.GetHashCode());
             Assert.True(tracker.IsUpdated);
         }
-        
+
         [Test]
         public void CreateEventWhenEventAndTrackerCustomizationDiffersAndCustomizationIsNotRequired_CreatesEvent()
         {
             var tracker = TestingMethods.CreateTrackerWithRequiredCustomization(Guid.NewGuid(), "tracker",
                 new TrackerCustomizationSettings(
-                    true, 
                     true,
-                    Option<string>.Some("meter"), 
-                    true, 
-                    false, 
-                    true, 
+                    true,
+                    Option<string>.Some("meter"),
+                    true,
+                    false,
+                    true,
                     false));
             _trackerRepository.SaveTracker(tracker);
-            
+
             var createdEventId = _eventService.CreateEvent(tracker.CreatorId, tracker.Id, DateTimeOffset.Now,
+                "Event title",
                 new EventCustomParameters());
-            
+
             Assert.True(_eventRepository.IsContainEvent(createdEventId));
             Assert.True(tracker.IsUpdated);
         }
-        
+
         [Test]
         public void GetEventWhenNoRequiredEventInRepository_ThrowsException()
         {
             Assert.Throws<EventNotFoundException>(() =>
                 _eventService.GetEvent(Guid.NewGuid(), Guid.NewGuid()));
         }
-        
+
         [Test]
         public void GetEventWhenUserAskNotHisOwnEvent_ThrowsException()
         {
             var eventOfAnotherUser = TestingMethods.CreateEvent(Guid.NewGuid(), Guid.NewGuid());
             _eventRepository.SaveEvent(eventOfAnotherUser);
-            
+
             Assert.Throws<NoPermissionsForEventException>(() =>
                 _eventService.GetEvent(Guid.NewGuid(), eventOfAnotherUser.Id));
         }
-        
+
         [Test]
         public void GetEventGoodCase_ReturnEvent()
         {
             _eventRepository.SaveEvent(_event);
 
             var eventFromService = _eventService.GetEvent(_event.CreatorId, _event.Id);
-            
-            Assert.AreEqual(_event.GetHashCode(),eventFromService.GetHashCode());
+
+            Assert.AreEqual(_event.GetHashCode(), eventFromService.GetHashCode());
             Assert.True(_tracker.IsUpdated);
         }
 
@@ -153,40 +154,40 @@ namespace ItHappened.UnitTests.ServicesTests
             Assert.Throws<TrackerNotFoundException>(() =>
                 _eventService.GetAllTrackerEvents(Guid.NewGuid(), Guid.NewGuid()));
         }
-        
+
         [Test]
         public void GetAllTrackerEventsWhenUserAskNotHisTracker_ThrowsRestException()
         {
             _trackerRepository.SaveTracker(_tracker);
-            
+
             Assert.Throws<NoPermissionsForTrackerException>(() =>
                 _eventService.GetAllTrackerEvents(Guid.NewGuid(), _tracker.Id));
         }
-        
+
         [Test]
         public void GetAllTrackerEventsGoodCase_ReturnsCollectionOfEvents()
         {
             _trackerRepository.SaveTracker(_tracker);
             var event2 = TestingMethods.CreateEvent(_tracker.Id, _tracker.CreatorId);
-            _eventRepository.AddRangeOfEvents(new []{_event, event2});
+            _eventRepository.AddRangeOfEvents(new[] {_event, event2});
             const int expected = 2;
-            
+
             var events = _eventService.GetAllTrackerEvents(_tracker.CreatorId, _tracker.Id);
-            
+
             Assert.AreEqual(expected, events.Count);
             Assert.AreEqual(_event.GetHashCode(), events.First().GetHashCode());
             Assert.AreEqual(event2.GetHashCode(), events.Last().GetHashCode());
         }
-        
+
         [Test]
         public void GetAllTrackerEventsWhenTrackerHasNoEvents_ReturnsEmptyCollection()
         {
             var tracker = TestingMethods.CreateTrackerWithDefaultCustomization(Guid.NewGuid(), "Tracker");
             _trackerRepository.SaveTracker(tracker);
             const int expected = 0;
-            
+
             var events = _eventService.GetAllTrackerEvents(tracker.CreatorId, tracker.Id);
-            
+
             Assert.AreEqual(expected, events.Count);
         }
 
@@ -199,56 +200,58 @@ namespace ItHappened.UnitTests.ServicesTests
                     DateTimeOffset.Now,
                     new EventCustomParameters()));
         }
-        
+
         [Test]
         public void EditEventWhenUserAskNotHisEvent_ThrowsException()
         {
             _trackerRepository.SaveTracker(_tracker);
             _eventRepository.SaveEvent(_event);
-            
+
             Assert.Throws<NoPermissionsForEventException>(() =>
                 _eventService.EditEvent(Guid.NewGuid(),
                     _event.Id,
                     DateTimeOffset.Now,
                     new EventCustomParameters()));
         }
-        
+
         [Test]
-        public void EditEventWhenNewCustomizationDontMatchTrackerCustomizationAndCustomizationIsRequired_ThrowsException()
+        public void
+            EditEventWhenNewCustomizationDontMatchTrackerCustomizationAndCustomizationIsRequired_ThrowsException()
         {
             var tracker = TestingMethods.CreateTrackerWithRequiredCustomization(Guid.NewGuid(), "tracker",
                 new TrackerCustomizationSettings(
-                    true, 
                     true,
-                    Option<string>.Some("meter"), 
-                    true, 
-                    false, 
-                    true, 
+                    true,
+                    Option<string>.Some("meter"),
+                    true,
+                    false,
+                    true,
                     true));
             _trackerRepository.SaveTracker(tracker);
             var oldEvent = TestingMethods.CreateEvent(tracker.Id, tracker.CreatorId);
             _eventRepository.SaveEvent(oldEvent);
-            
+
             Assert.Throws<InvalidEventForTrackerException>(() =>
                 _eventService.EditEvent(tracker.CreatorId, oldEvent.Id, DateTimeOffset.Now,
                     new EventCustomParameters()));
         }
-        
-        
+
+
         [Test]
-        public void EditEventWhenNewCustomizationMatchTrackerCustomizationAndCustomizationIsRequired_EventInRepositoryUpdated()
+        public void
+            EditEventWhenNewCustomizationMatchTrackerCustomizationAndCustomizationIsRequired_EventInRepositoryUpdated()
         {
             var tracker = TestingMethods.CreateTrackerWithRequiredCustomization(Guid.NewGuid(), "tracker",
                 new TrackerCustomizationSettings(
-                    true, 
                     true,
-                    Option<string>.Some("meter"), 
-                    false, 
-                    true, 
-                    false, 
+                    true,
+                    Option<string>.Some("meter"),
+                    false,
+                    true,
+                    false,
                     true));
             _trackerRepository.SaveTracker(tracker);
-            var oldEvent = new Event(Guid.NewGuid(), tracker.CreatorId, tracker.Id, DateTimeOffset.Now, 
+            var oldEvent = new Event(Guid.NewGuid(), tracker.CreatorId, tracker.Id, DateTimeOffset.Now, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.Some(new Photo(photoBytes: new byte[5])),
                     Option<double>.Some(1),
@@ -256,33 +259,34 @@ namespace ItHappened.UnitTests.ServicesTests
                     Option<GeoTag>.Some(new GeoTag(10, 20)),
                     Option<Comment>.None));
             _eventRepository.SaveEvent(oldEvent);
-            
+
             var updatedCustomizationParameters = new EventCustomParameters(
                 Option<Photo>.Some(new Photo(photoBytes: new byte[7])),
                 Option<double>.Some(15),
                 Option<double>.None,
                 Option<GeoTag>.Some(new GeoTag(30, 40)),
                 Option<Comment>.None);
-            
+
             _eventService.EditEvent(tracker.CreatorId, oldEvent.Id, DateTimeOffset.Now,
                 updatedCustomizationParameters);
-            
-            Assert.AreEqual(updatedCustomizationParameters.GetHashCode(), 
+
+            Assert.AreEqual(updatedCustomizationParameters.GetHashCode(),
                 _eventRepository.LoadEvent(oldEvent.Id).CustomizationsParameters.GetHashCode());
             Assert.True(tracker.IsUpdated);
         }
-        
+
         [Test]
-        public void EditEventWhenNewCustomizationDontMatchTrackerCustomizationAndCustomizationNotRequired_EventInRepositoryUpdated()
+        public void
+            EditEventWhenNewCustomizationDontMatchTrackerCustomizationAndCustomizationNotRequired_EventInRepositoryUpdated()
         {
             var tracker = TestingMethods.CreateTrackerWithRequiredCustomization(Guid.NewGuid(), "tracker",
                 new TrackerCustomizationSettings(
-                    true, 
                     true,
-                    Option<string>.Some("meter"), 
-                    true, 
-                    false, 
-                    true, 
+                    true,
+                    Option<string>.Some("meter"),
+                    true,
+                    false,
+                    true,
                     false));
             _trackerRepository.SaveTracker(tracker);
             var oldEvent = TestingMethods.CreateEvent(tracker.Id, tracker.CreatorId);
@@ -290,8 +294,8 @@ namespace ItHappened.UnitTests.ServicesTests
 
             _eventService.EditEvent(tracker.CreatorId, oldEvent.Id, DateTimeOffset.Now,
                 new EventCustomParameters());
-            
-            Assert.AreNotEqual(oldEvent.GetHashCode(), 
+
+            Assert.AreNotEqual(oldEvent.GetHashCode(),
                 _eventRepository.LoadEvent(oldEvent.Id).GetHashCode());
             Assert.True(tracker.IsUpdated);
         }
@@ -303,25 +307,25 @@ namespace ItHappened.UnitTests.ServicesTests
                 _eventService.DeleteEvent(Guid.NewGuid(),
                     Guid.NewGuid()));
         }
-        
+
         [Test]
         public void DeleteEventWhenUserAskNotHisEvent_ThrowsRestException()
         {
             _eventRepository.SaveEvent(_event);
-            
+
             Assert.Throws<NoPermissionsForEventException>(() =>
                 _eventService.DeleteEvent(Guid.NewGuid(),
                     _event.Id));
         }
-        
+
         [Test]
         public void DeleteEventGoodCase_EventRemovedFromRepository()
         {
             _trackerRepository.SaveTracker(_tracker);
             _eventRepository.SaveEvent(_event);
-            
+
             _eventService.DeleteEvent(_event.CreatorId, _event.Id);
-            
+
             Assert.False(_eventRepository.IsContainEvent(_event.Id));
             Assert.True(_tracker.IsUpdated);
         }

--- a/ItHappened.UnitTests/StatisticsCalculatorsTests/SpecificDayTimeEventCalculatorTest.cs
+++ b/ItHappened.UnitTests/StatisticsCalculatorsTests/SpecificDayTimeEventCalculatorTest.cs
@@ -63,7 +63,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
         
         private static Event CreateEventWithNameAndDateTime(Guid userId, Guid trackerId, string dateTime)
         {
-            return new Event(Guid.NewGuid(), userId, trackerId, DateTime.Parse(dateTime), new EventCustomParameters());
+            return new Event(Guid.NewGuid(), userId, trackerId, DateTime.Parse(dateTime), "Event title", new EventCustomParameters());
         }
     }
 }

--- a/ItHappened.UnitTests/StatisticsCalculatorsTests/TestingMethods.cs
+++ b/ItHappened.UnitTests/StatisticsCalculatorsTests/TestingMethods.cs
@@ -16,13 +16,14 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
         {
             return new EventTracker(Guid.NewGuid(), userId, name, new TrackerCustomizationSettings());
         }
-        
-        public static EventTracker CreateTrackerWithRequiredCustomization(Guid userId, string name, TrackerCustomizationSettings trackerCustomizationSettings)
+
+        public static EventTracker CreateTrackerWithRequiredCustomization(Guid userId, string name,
+            TrackerCustomizationSettings trackerCustomizationSettings)
         {
             return new EventTracker(Guid.NewGuid(), userId, name,
                 trackerCustomizationSettings);
         }
-        
+
         public static EventTracker CreateTrackerWithScale(Guid userId, string scale)
         {
             return new EventTracker(userId, Guid.NewGuid(), "Tracker name",
@@ -33,7 +34,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
                     false,
                     false, false));
         }
-        
+
         public static (IReadOnlyCollection<Event> events, List<double> Rating) CreateEventsWithRating(Guid trackerId,
             Guid userId,
             int num)
@@ -142,7 +143,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow, "Event title", 
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,
@@ -157,7 +158,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                dateTime,
+                dateTime, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,
@@ -172,7 +173,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow, "Event title", 
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,
@@ -188,7 +189,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                dateTime,
+                dateTime, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,
@@ -203,7 +204,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,
@@ -218,7 +219,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                time,
+                time, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,
@@ -234,7 +235,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                time,
+                time, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.Some(photo),
                     Option<double>.Some(scale),
@@ -251,7 +252,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 creatorId,
                 trackerId,
-                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,
@@ -269,7 +270,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 creatorId,
                 trackerId,
-                RandomDayFromTo(from, to),
+                RandomDayFromTo(from, to), "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,
@@ -288,7 +289,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 creatorId,
                 trackerId,
-                RandomDayFromTo(from, to),
+                RandomDayFromTo(from, to), "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,
@@ -307,7 +308,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                fixDate,
+                fixDate, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,
@@ -317,22 +318,24 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
                 )
             );
         }
+
         public static Event CreateEventFixDate(Guid trackerId, Guid userId, DateTimeOffset fixDate)
         {
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                fixDate,
+                fixDate, "Event title",
                 new EventCustomParameters()
             );
         }
+
         public static Event CreateEventWithRatingAndFixDate(Guid trackerId, Guid userId, double rating,
             DateTimeOffset fixDate)
         {
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                fixDate,
+                fixDate, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,
@@ -349,7 +352,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                fixTime,
+                fixTime, "Event title",
                 new EventCustomParameters()
             );
         }
@@ -366,7 +369,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 creatorId,
                 trackerId,
-                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.Some(scale),
@@ -381,7 +384,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 creatorId,
                 trackerId,
-                dateTime,
+                dateTime, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.Some(scale),
@@ -396,7 +399,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,
@@ -411,7 +414,7 @@ namespace ItHappened.UnitTests.StatisticsCalculatorsTests
             return new Event(Guid.NewGuid(),
                 userId,
                 trackerId,
-                dateTime,
+                dateTime, "Event title",
                 new EventCustomParameters(
                     Option<Photo>.None,
                     Option<double>.None,


### PR DESCRIPTION
Добавил обязательное поле title к событию (Event).
Поменял класс Event, EventRequest, EventDto. В БД, в таблице Event, добавил Title колонку 
Не забудьте обновить свои postman колекции
```
{
    "happensDate": "2020-10-26T07:00:35.109Z",
    "title" : "New event title", <= теперь обязательное 
    "scale": 10,
    "rating": 5,
    "geoTag": {
        "gpsLat": 35.109,
        "gpsLng": 34.015
    },
    "comment": "Tracker 1 Comment 1"
    
}
```