### PR TITLE
Db/unique trackers name. Issue #227

### DIFF
--- a/ItHappened.Application/Errors/DuplicateTrackerNameException.cs
+++ b/ItHappened.Application/Errors/DuplicateTrackerNameException.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Net;
+
+namespace ItHappened.Application.Errors
+{
+    public class DuplicateTrackerNameException : BusinessException
+    {
+        public DuplicateTrackerNameException(string name)
+            : base(HttpStatusCode.BadRequest,
+                "Cant create Tracker with already existing name ",
+                new Dictionary<string, object> {{"Tracker name", name}})
+        {
+        }
+    }
+}

--- a/ItHappened.Application/Services/TrackerService/ITrackerService.cs
+++ b/ItHappened.Application/Services/TrackerService/ITrackerService.cs
@@ -6,7 +6,7 @@ namespace ItHappened.Application.Services.TrackerService
 {
     public interface ITrackerService
     {
-        Guid CreateEventTracker(Guid creatorId, string name, TrackerCustomizationSettings customizationSettings);
+        Guid CreateEventTracker(Guid creatorId, string trackerName, TrackerCustomizationSettings customizationSettings);
         EventTracker GetEventTracker(Guid actorId, Guid trackerId);
         IReadOnlyCollection<EventTracker> GetEventTrackers(Guid actorId);
 

--- a/ItHappened.Application/Services/TrackerService/TrackerService.cs
+++ b/ItHappened.Application/Services/TrackerService/TrackerService.cs
@@ -14,9 +14,13 @@ namespace ItHappened.Application.Services.TrackerService
             _trackerRepository = trackerRepository;
         }
         
-        public Guid CreateEventTracker(Guid creatorId, string name, TrackerCustomizationSettings customizationSettings)
+        public Guid CreateEventTracker(Guid creatorId, string trackerName, TrackerCustomizationSettings customizationSettings)
         {
-            var tracker = new EventTracker(Guid.NewGuid(), creatorId, name, customizationSettings);
+            var tracker = new EventTracker(Guid.NewGuid(), creatorId, trackerName, customizationSettings);
+            if (_trackerRepository.IsExistTrackerWithSameName(creatorId, trackerName))
+            {
+                throw new DuplicateTrackerNameException(trackerName);
+            }
             _trackerRepository.SaveTracker(tracker);
             return tracker.Id;
         }

--- a/ItHappened.Domain/Repositories/ITrackerRepository.cs
+++ b/ItHappened.Domain/Repositories/ITrackerRepository.cs
@@ -11,5 +11,6 @@ namespace ItHappened.Domain
         void UpdateTracker(EventTracker eventTracker);
         void DeleteTracker(Guid trackerId);
         bool IsContainTracker(Guid trackerId);
+        bool IsExistTrackerWithSameName(Guid creatorId, string trackerName);
     }
 }

--- a/ItHappened.Infrastructure/EFCoreRepositories/EFTrackerRepository.cs
+++ b/ItHappened.Infrastructure/EFCoreRepositories/EFTrackerRepository.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
+using ItHappened.Application.Errors;
 using ItHappened.Domain;
 using ItHappened.Infrastructure.Mappers;
 using LanguageExt.UnsafeValueAccess;
@@ -11,6 +12,7 @@ namespace ItHappened.Infrastructure.EFCoreRepositories
     // ReSharper disable once InconsistentNaming
     public class EFTrackerRepository : ITrackerRepository
     {
+        private const int InsertKeyWithDuplicateRowErrorCode = 2601;
         private readonly ItHappenedDbContext _context;
         private readonly IMapper _mapper;
 
@@ -19,7 +21,7 @@ namespace ItHappened.Infrastructure.EFCoreRepositories
             _context = context;
             _mapper = mapper;
         }
-        
+
         public void SaveTracker(EventTracker newTracker)
         {
             var trackerDto = _mapper.Map<EventTrackerDto>(newTracker);
@@ -34,8 +36,8 @@ namespace ItHappened.Infrastructure.EFCoreRepositories
 
         public IReadOnlyCollection<EventTracker> LoadAllUserTrackers(Guid userId)
         {
-           var trackersDto = _context.EventTrackers.Where(tracker => tracker.CreatorId == userId);
-           return _mapper.Map<EventTracker[]>(trackersDto.ToList());
+            var trackersDto = _context.EventTrackers.Where(tracker => tracker.CreatorId == userId);
+            return _mapper.Map<EventTracker[]>(trackersDto.ToList());
         }
 
         public void UpdateTracker(EventTracker eventTracker)
@@ -66,7 +68,12 @@ namespace ItHappened.Infrastructure.EFCoreRepositories
 
         public bool IsContainTracker(Guid trackerId)
         {
-            return _context.EventTrackers.Any(o => o.Id == trackerId);
+            return _context.EventTrackers.Any(tracker => tracker.Id == trackerId);
+        }
+
+        public bool IsExistTrackerWithSameName(Guid creatorId, string trackerName)
+        {
+            return _context.EventTrackers.Any(tracker => tracker.CreatorId == creatorId && tracker.Name == trackerName);
         }
     }
 }

--- a/ItHappened.Infrastructure/InMemoryRepositories/TrackerRepository.cs
+++ b/ItHappened.Infrastructure/InMemoryRepositories/TrackerRepository.cs
@@ -23,7 +23,13 @@ namespace ItHappened.Infrastructure.Repositories
         {
             return _eventTrackers.ContainsKey(trackerId);
         }
-        
+
+        public bool IsExistTrackerWithSameName(Guid creatorId, string trackerName)
+        {
+            return _eventTrackers
+                .All(tracker => tracker.Value.CreatorId != creatorId || tracker.Value.Name != trackerName);
+        }
+
         public IReadOnlyCollection<EventTracker> LoadAllUserTrackers(Guid userId)
         {
             return _eventTrackers

--- a/ItHappened.Infrastructure/InMemoryRepositories/TrackerRepository.cs
+++ b/ItHappened.Infrastructure/InMemoryRepositories/TrackerRepository.cs
@@ -26,8 +26,12 @@ namespace ItHappened.Infrastructure.Repositories
 
         public bool IsExistTrackerWithSameName(Guid creatorId, string trackerName)
         {
+            if (!_eventTrackers.Any())
+            {
+                return false;
+            }
             return _eventTrackers
-                .All(tracker => tracker.Value.CreatorId != creatorId || tracker.Value.Name != trackerName);
+                .All(tracker => tracker.Value.CreatorId == creatorId && tracker.Value.Name == trackerName);
         }
 
         public IReadOnlyCollection<EventTracker> LoadAllUserTrackers(Guid userId)

--- a/ItHappened.UnitTests/ServicesTests/TrackerServiceTests.cs
+++ b/ItHappened.UnitTests/ServicesTests/TrackerServiceTests.cs
@@ -54,9 +54,41 @@ namespace ItHappened.UnitTests.ServicesTests
         }
 
         [Test]
+        public void TwoTrackersWithSameName()
+        {
+            var creatorId = Guid.NewGuid();
+            var sameTrackerName = "trackerName";
+            var tracker1Id = _trackerService.CreateEventTracker(creatorId, sameTrackerName,
+                new TrackerCustomizationSettings(
+                    true,
+                    true,
+                    Option<string>.Some("meter"),
+                    false,
+                    true,
+                    false,
+                    false));
+
+
+            Assert.Throws<DuplicateTrackerNameException>(() =>
+                {
+                    var tracker2Id = _trackerService.CreateEventTracker(creatorId, sameTrackerName,
+                        new TrackerCustomizationSettings(
+                            true,
+                            true,
+                            Option<string>.Some("meter"),
+                            false,
+                            true,
+                            false,
+                            false));
+                }
+            );  
+        }
+
+        [Test]
         public void GetTrackerWhenNoSuchTrackerInRepository_ThrowsException()
         {
-            Assert.Throws<TrackerNotFoundException>(() => _trackerService.GetEventTracker(Guid.NewGuid(), Guid.NewGuid()));
+            Assert.Throws<TrackerNotFoundException>(() =>
+                _trackerService.GetEventTracker(Guid.NewGuid(), Guid.NewGuid()));
         }
 
         [Test]
@@ -64,7 +96,8 @@ namespace ItHappened.UnitTests.ServicesTests
         {
             _trackerRepository.SaveTracker(_tracker);
 
-            Assert.Throws<NoPermissionsForTrackerException>(() => _trackerService.GetEventTracker(Guid.NewGuid(), _tracker.Id));
+            Assert.Throws<NoPermissionsForTrackerException>(() =>
+                _trackerService.GetEventTracker(Guid.NewGuid(), _tracker.Id));
         }
 
         [Test]
@@ -142,7 +175,8 @@ namespace ItHappened.UnitTests.ServicesTests
         [Test]
         public void DeleteTrackerWhenNoSuchTrackerInRepository_ThrowsException()
         {
-            Assert.Throws<TrackerNotFoundException>(() => _trackerService.DeleteEventTracker(Guid.NewGuid(), Guid.NewGuid()));
+            Assert.Throws<TrackerNotFoundException>(() =>
+                _trackerService.DeleteEventTracker(Guid.NewGuid(), Guid.NewGuid()));
         }
 
         [Test]
@@ -150,7 +184,8 @@ namespace ItHappened.UnitTests.ServicesTests
         {
             _trackerRepository.SaveTracker(_tracker);
 
-            Assert.Throws<NoPermissionsForTrackerException>(() => _trackerService.DeleteEventTracker(Guid.NewGuid(), _tracker.Id));
+            Assert.Throws<NoPermissionsForTrackerException>(() =>
+                _trackerService.DeleteEventTracker(Guid.NewGuid(), _tracker.Id));
         }
 
         [Test]


### PR DESCRIPTION
В случае попытки пользователя добавить трекер с одинаковым именем бросается исключение DuplicateTrackerNameException  

Код проверки. TrackerService.cs
``` 
  public Guid CreateEventTracker(Guid creatorId, string trackerName, TrackerCustomizationSettings customizationSettings)
        {
            var tracker = new EventTracker(Guid.NewGuid(), creatorId, trackerName, customizationSettings); 
            if (_trackerRepository.IsExistTrackerWithSameName(creatorId, trackerName)) //здесь происходит проверка 
            {
                throw new DuplicateTrackerNameException(trackerName);
            }
            _trackerRepository.SaveTracker(tracker);
            return tracker.Id;
        }
```
Код искючения. DuplicateTrackerNameException.cs
```
 public class DuplicateTrackerNameException : BusinessException
    {
        public DuplicateTrackerNameException(string name)
            : base(HttpStatusCode.BadRequest,
                "Cant create Tracker with already existing name ",
                new Dictionary<string, object> {{"Tracker name", name}})
        {
        }
    }
```


DuplicateTrackerNameException 
![image](https://user-images.githubusercontent.com/3910972/98086987-8a56cb80-1e90-11eb-8c34-fce754ef7593.png)
